### PR TITLE
Bartman toolchain: -fno-optimize-sibling-calls when M68K_CPU ≠ 68000

### DIFF
--- a/m68k-bartman.cmake
+++ b/m68k-bartman.cmake
@@ -35,17 +35,16 @@ else()
 	set(FPU_FLAGS -mhard-float)
 endif()
 
-# Sibling-call ("tail call") optimization: Release adds -foptimize-sibling-calls
-# below. For 68020+ that breaks valid code (bad prologues/epilogues or call
-# patterns vs. -m68020, AmigaOS ABI, and typical bare-metal/interrupt glue).
-# Force -fno-optimize-sibling-calls for non-68000 and skip the Release -fopt
-# so it cannot override.
+# Sibling-call ("tail call") optimization: Release enables it for 68000; for
+# 68020+ it breaks valid code (bad prologues/epilogues or call patterns vs.
+# -m68020, AmigaOS ABI, and typical bare-metal/interrupt glue). One flag slot:
+# -foptimize-sibling-calls (68000) vs -fno-optimize-sibling-calls (else).
+# Non-68000 also gets it in FLAGS_COMMON so Debug/RelWithDebInfo are safe;
+# Release repeats it after other opts so nothing overrides -fno-.
 if(M68K_CPU STREQUAL "68000")
-	set(M68K_NO_SIBLING_CALLS "")
-	set(M68K_RELEASE_SIBLING_CALL_OPT -foptimize-sibling-calls)
+	set(M68K_SIBLING_CALL_OPT -foptimize-sibling-calls)
 else()
-	set(M68K_NO_SIBLING_CALLS -fno-optimize-sibling-calls)
-	set(M68K_RELEASE_SIBLING_CALL_OPT "")
+	set(M68K_SIBLING_CALL_OPT -fno-optimize-sibling-calls)
 endif()
 
 # Extra flags
@@ -89,7 +88,11 @@ if(WIN32)
 endif()
 
 # Compiler flags
-set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} ${M68K_NO_SIBLING_CALLS} -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
+set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS}")
+if(NOT M68K_CPU STREQUAL "68000")
+	string(APPEND FLAGS_COMMON " ${M68K_SIBLING_CALL_OPT}")
+endif()
+string(APPEND FLAGS_COMMON " -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
 set(CMAKE_C_FLAGS_INIT "${FLAGS_COMMON} ${TOOLCHAIN_CFLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${FLAGS_COMMON} -fno-exceptions ${TOOLCHAIN_CXXFLAGS}")
 set(CMAKE_ASM_FLAGS_INIT "-Wa,-g,--register-prefix-optional -m${M68K_CPU}")
@@ -106,7 +109,7 @@ endforeach()
 # Ignore CMake's own calls later after toolchain has been processed
 macro(__compiler_gnu lang)
 endmacro()
-set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat ${M68K_RELEASE_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat ${M68K_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g ${CMAKE_C_FLAGS_RELEASE_INIT}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_C_FLAGS_RELEASE_INIT} -fno-exceptions")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT} -fno-exceptions")

--- a/m68k-bartman.cmake
+++ b/m68k-bartman.cmake
@@ -81,7 +81,7 @@ set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} -fomit
 # (" -foptimize-sibling-calls" or empty).
 set(M68K_SIBLING_CALL_OPT "")
 if(M68K_CPU STREQUAL "68000")
-	set(M68K_SIBLING_CALL_OPT " -foptimize-sibling-calls")
+	set(M68K_SIBLING_CALL_OPT "-foptimize-sibling-calls")
 else()
 	string(APPEND FLAGS_COMMON " -fno-optimize-sibling-calls")
 endif()
@@ -101,7 +101,7 @@ endforeach()
 # Ignore CMake's own calls later after toolchain has been processed
 macro(__compiler_gnu lang)
 endmacro()
-set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat${M68K_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat ${M68K_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g ${CMAKE_C_FLAGS_RELEASE_INIT}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_C_FLAGS_RELEASE_INIT} -fno-exceptions")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT} -fno-exceptions")

--- a/m68k-bartman.cmake
+++ b/m68k-bartman.cmake
@@ -77,10 +77,10 @@ endif()
 
 # Compiler flags
 set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
-# Sibling-call: 020+ appends -fno to FLAGS_COMMON; 68000 uses M68K_SIBLING_CALL_OPT as Release-only suffix
+# Sibling-call: 020+ appends -fno to FLAGS_COMMON; 68000/010 uses M68K_SIBLING_CALL_OPT as Release-only suffix
 # (" -foptimize-sibling-calls" or empty).
 set(M68K_SIBLING_CALL_OPT "")
-if(M68K_CPU STREQUAL "68000")
+if(M68K_CPU STREQUAL "68000" OR M68K_CPU STREQUAL "68010")
 	set(M68K_SIBLING_CALL_OPT "-foptimize-sibling-calls")
 else()
 	string(APPEND FLAGS_COMMON " -fno-optimize-sibling-calls")

--- a/m68k-bartman.cmake
+++ b/m68k-bartman.cmake
@@ -35,6 +35,19 @@ else()
 	set(FPU_FLAGS -mhard-float)
 endif()
 
+# Sibling-call ("tail call") optimization: Release adds -foptimize-sibling-calls
+# below. For 68020+ that breaks valid code (bad prologues/epilogues or call
+# patterns vs. -m68020, AmigaOS ABI, and typical bare-metal/interrupt glue).
+# Force -fno-optimize-sibling-calls for non-68000 and skip the Release -fopt
+# so it cannot override.
+if(M68K_CPU STREQUAL "68000")
+	set(M68K_NO_SIBLING_CALLS "")
+	set(M68K_RELEASE_SIBLING_CALL_OPT -foptimize-sibling-calls)
+else()
+	set(M68K_NO_SIBLING_CALLS -fno-optimize-sibling-calls)
+	set(M68K_RELEASE_SIBLING_CALL_OPT "")
+endif()
+
 # Extra flags
 set(TOOLCHAIN_CFLAGS "${M68K_CFLAGS}" CACHE STRING "CFLAGS")
 set(TOOLCHAIN_CXXFLAGS "${M68K_CXXFLAGS}" CACHE STRING "CXXFLAGS")
@@ -76,7 +89,7 @@ if(WIN32)
 endif()
 
 # Compiler flags
-set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
+set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} ${M68K_NO_SIBLING_CALLS} -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
 set(CMAKE_C_FLAGS_INIT "${FLAGS_COMMON} ${TOOLCHAIN_CFLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${FLAGS_COMMON} -fno-exceptions ${TOOLCHAIN_CXXFLAGS}")
 set(CMAKE_ASM_FLAGS_INIT "-Wa,-g,--register-prefix-optional -m${M68K_CPU}")
@@ -93,7 +106,7 @@ endforeach()
 # Ignore CMake's own calls later after toolchain has been processed
 macro(__compiler_gnu lang)
 endmacro()
-set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat -foptimize-sibling-calls -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat ${M68K_RELEASE_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g ${CMAKE_C_FLAGS_RELEASE_INIT}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_C_FLAGS_RELEASE_INIT} -fno-exceptions")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT} -fno-exceptions")

--- a/m68k-bartman.cmake
+++ b/m68k-bartman.cmake
@@ -35,18 +35,6 @@ else()
 	set(FPU_FLAGS -mhard-float)
 endif()
 
-# Sibling-call ("tail call") optimization: Release enables it for 68000; for
-# 68020+ it breaks valid code (bad prologues/epilogues or call patterns vs.
-# -m68020, AmigaOS ABI, and typical bare-metal/interrupt glue). One flag slot:
-# -foptimize-sibling-calls (68000) vs -fno-optimize-sibling-calls (else).
-# Non-68000 also gets it in FLAGS_COMMON so Debug/RelWithDebInfo are safe;
-# Release repeats it after other opts so nothing overrides -fno-.
-if(M68K_CPU STREQUAL "68000")
-	set(M68K_SIBLING_CALL_OPT -foptimize-sibling-calls)
-else()
-	set(M68K_SIBLING_CALL_OPT -fno-optimize-sibling-calls)
-endif()
-
 # Extra flags
 set(TOOLCHAIN_CFLAGS "${M68K_CFLAGS}" CACHE STRING "CFLAGS")
 set(TOOLCHAIN_CXXFLAGS "${M68K_CXXFLAGS}" CACHE STRING "CXXFLAGS")
@@ -88,11 +76,15 @@ if(WIN32)
 endif()
 
 # Compiler flags
-set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS}")
-if(NOT M68K_CPU STREQUAL "68000")
-	string(APPEND FLAGS_COMMON " ${M68K_SIBLING_CALL_OPT}")
+set(FLAGS_COMMON "${TOOLCHAIN_COMMON} -MP -MMD -m${M68K_CPU} ${FPU_FLAGS} -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
+# Sibling-call: 020+ appends -fno to FLAGS_COMMON; 68000 uses M68K_SIBLING_CALL_OPT as Release-only suffix
+# (" -foptimize-sibling-calls" or empty).
+set(M68K_SIBLING_CALL_OPT "")
+if(M68K_CPU STREQUAL "68000")
+	set(M68K_SIBLING_CALL_OPT " -foptimize-sibling-calls")
+else()
+	string(APPEND FLAGS_COMMON " -fno-optimize-sibling-calls")
 endif()
-string(APPEND FLAGS_COMMON " -fomit-frame-pointer -nostdlib -Wno-unused-function -Wno-volatile-register-var -fno-tree-loop-distribution -flto -fwhole-program -fdata-sections -ffunction-sections")
 set(CMAKE_C_FLAGS_INIT "${FLAGS_COMMON} ${TOOLCHAIN_CFLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${FLAGS_COMMON} -fno-exceptions ${TOOLCHAIN_CXXFLAGS}")
 set(CMAKE_ASM_FLAGS_INIT "-Wa,-g,--register-prefix-optional -m${M68K_CPU}")
@@ -109,7 +101,7 @@ endforeach()
 # Ignore CMake's own calls later after toolchain has been processed
 macro(__compiler_gnu lang)
 endmacro()
-set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat ${M68K_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
+set(CMAKE_C_FLAGS_RELEASE_INIT "-O1 -DNDEBUG ${FLAGS_COMMON} -falign-functions -falign-jumps -falign-labels -falign-loops -fcaller-saves -fcode-hoisting -fcse-follow-jumps -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fdevirtualize-speculatively -fexpensive-optimizations -ffinite-loops -fgcse -fgcse-lm -finline-functions -finline-small-functions -findirect-inlining -fipa-bit-cp -fipa-cp -fipa-icf -fipa-ra -fipa-sra -fipa-vrp -fisolate-erroneous-paths-dereference -flra-remat${M68K_SIBLING_CALL_OPT} -fpartial-inlining -fpeephole2 -freorder-functions -frerun-cse-after-loop -fstore-merging -fstrict-aliasing -fthread-jumps -ftree-pre -ftree-switch-conversion -ftree-vrp -fgcse-after-reload -floop-unroll-and-jam -fpeel-loops -fpredictive-commoning -fsplit-loops -fsplit-paths -fallow-store-data-races")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g ${CMAKE_C_FLAGS_RELEASE_INIT}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_C_FLAGS_RELEASE_INIT} -fno-exceptions")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT} -fno-exceptions")


### PR DESCRIPTION
### PR title

**Bartman toolchain: sibling-call flags (`68000` vs `020+`)**

---

### Summary

This PR cleans up **sibling-call (“tail call”) optimization** in [`m68k-bartman.cmake`](m68k-bartman.cmake) so behaviour is obvious, non-contradictory, and not duplicated on the command line.

---

### Behaviour

| Target | `FLAGS_COMMON` | Release / RelWithDebInfo |
|--------|----------------|--------------------------|
| **`M68K_CPU = 68000`** | No sibling-call flag | `-foptimize-sibling-calls` via `M68K_SIBLING_CALL_OPT` after `-flra-remat` |
| **`M68K_CPU ≠ 68000`** | Appends `-fno-optimize-sibling-calls` once | Same `-fno` comes from expanded `FLAGS_COMMON` (not repeated in `CMAKE_C_FLAGS_RELEASE_INIT`) |

---

### Why this flag

GCC’s **sibling-call / tail-call** optimization (`-foptimize-sibling-calls`) can rewrite call sequences into forms that clash with **`68020+` instruction selection** (`-m68020`, etc.), the **Amiga OS calling convention**, and **typical bare-metal / interrupt-oriented code**. In practice that has produced **miscompiled or crashing** binaries for non‑`68000` targets unless sibling-call optimization is turned off (**`-fno-optimize-sibling-calls`**).

Targets that identify as **`68000`** are handled differently: **`FLAGS_COMMON`** does **not** enable sibling-call optimization (so Debug stays clear), while the optimized Release-style flag line injects **`-foptimize-sibling-calls`** only via **`M68K_SIBLING_CALL_OPT`** (after `-flra-remat`), matching the prior intent for baseline 68000 Release builds.

---

### Notes

- **`M68K_SIBLING_CALL_OPT`** is now only the **Release-only suffix** (`" -foptimize-sibling-calls"` or empty), not an overloaded “sometimes `-f`, sometimes `-fno`” knob.

---

### How to verify

1. Configure with **`M68K_CPU=68000`**, build **Debug** and **Release**; Release should contain `-foptimize-sibling-calls` at the sibling-call injection point; Debug should not pull it in through `FLAGS_COMMON`.
2. Configure with **`M68K_CPU=68020`** (or any non‑68000), check the compile line for **`-fno-optimize-sibling-calls`** via `FLAGS_COMMON` and confirm your previously broken configs build/run.

---

### Commit message (optional)
